### PR TITLE
Update create-project.sh composer image

### DIFF
--- a/bin/create-project.sh
+++ b/bin/create-project.sh
@@ -21,7 +21,7 @@ case "$1" in
     ## TYPO3 CMS
     ###################################
     "typo3")
-        execInDir "$CODE_DIR" "docker run --rm -v $(pwd)/app:/app composer/composer:alpine create-project typo3/cms-base-distribution \"/app\""
+        execInDir "$CODE_DIR" "docker run --rm -v $(pwd)/app:/app composer create-project typo3/cms-base-distribution \"/app\""
         execInDir "$CODE_DIR" "touch web/FIRST_INSTALL"
         ;;
 
@@ -29,7 +29,7 @@ case "$1" in
     ## TYPO3 NEOS
     ###################################
     "neos")
-        execInDir "$CODE_DIR" "docker run --rm -v $(pwd)/app:/app composer/composer:alpine create-project typo3/neos-base-distribution \"/app\""
+        execInDir "$CODE_DIR" "docker run --rm -v $(pwd)/app:/app composer create-project typo3/neos-base-distribution \"/app\""
         ;;
 
     ###################################


### PR DESCRIPTION
The images from composer/composer are deprecated.
See here: https://hub.docker.com/r/composer/composer/

You could use the official composer image. 
See here: https://hub.docker.com/_/composer

Now the requirements (php ^7.1) are met.